### PR TITLE
Adding support for season and episode to support lookup in tvdb

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,10 +71,10 @@ Beim ersten Start  werden die notwendigen Information von der `Liste der Tatort-
 Ist dieser Cache älter als 24 Stunden wird er verworfen und die Daten erneut aus der Wikipedia bezogen.
 Mit der Option ``-c`` kann eine andere Cache-Datei gewählt werden.
 Die Option ``-r`` forciert ein Update des Cache, egal wann dieser zuletzt aktulaisiert wurde.
+Mit der Option ``-p`` kan ein anderes Namensschema gewählt werden.
 
-Das Namensschema ist derzeit fest codiert und müsste bei Bedarf in ``cli.py`` (Variable ``file_rename_pattern``) manuell angepasst werden.
-Dieses lautet derzeit ``{episode_index:0>4}--{location}--{title}--({team})``, wobei ``location`` der Heimatstadt/-region des jeweiligen
-Ermittlerteams entspricht. Die Heimatstadt ist die einzige Information die nicht direkt aus der Wikipedia stammt, sondern anhand eines
+Die Voreinstellung für das Namensschema lautet derzeit ``{episode_index:0>4}--{location}--{title}--({team})``, wobei ``location`` der Heimatstadt/-region des jeweiligen Ermittlerteams entspricht.
+Die Heimatstadt ist die einzige Information die nicht direkt aus der Wikipedia stammt, sondern anhand eines
 Mappings (``team_to_location`` in ``grabber.py``) aus dem Team abgeleitet wird. Derzeit sind alle Heimatstädte ab Episode 800 dort
 verzeichnet. Fehlen hier relevante „locations“, müssten diese ebenfalls händisch nachgetragen werden.
 

--- a/README.rst
+++ b/README.rst
@@ -93,6 +93,8 @@ Insgesamt stehen die folgenden Variablen für das Namensschema zur Verfügung:
 * ``case_index``: Fall-Nummer des jeweiligen Ermittlerteams
 * ``author``: Autor der Episode
 * ``director``: Regisseur der Episode
+* ``season``: Jahr der Erstausstrahlung
+* ``episode``: Laufende Episode im Jahr
 
 GitHub-Seite: https://github.com/DLFW/tatorter
 

--- a/src/tatorterp/cli.py
+++ b/src/tatorterp/cli.py
@@ -34,9 +34,9 @@ logger.setLevel(logging.INFO)
 
 # TVDB compatible naming pattern for use in Plex
 # Tatort - 2015x33 - Thiel und Boerne - 28 - Schwanensee.mp4
-file_rename_pattern_default = "Tatort - {season}x{episode:0>2} - {team} - {case_index} - {title}"
+#file_rename_pattern_default = "Tatort - {season}x{episode:0>2} - {team} - {case_index} - {title}"
 # 0978--Dresden--Auf einen Schlag--(Sieland, Gorniak, Mohr und Schnabel).mp4
-#file_rename_pattern_default = "{episode_index:0>4}--{location}--{title}"
+file_rename_pattern_default = "{episode_index:0>4}--{location}--{title}"
 
 def start():
     # get arguments

--- a/src/tatorterp/cli.py
+++ b/src/tatorterp/cli.py
@@ -34,7 +34,8 @@ logger = logging.getLogger("tatorter")
 logging.basicConfig()
 logger.setLevel(logging.INFO)
 
-file_rename_pattern = "{episode_index:0>4}--{location}--{title}--({team})"
+#file_rename_pattern = "[{episode_index:0>4}] - {location} -{title}"
+file_rename_pattern = "Tatort - {season}x{episode:0>2} - {team} - {case_index} - {title}"
 
 def start():
     # get arguments
@@ -69,12 +70,12 @@ def start():
         logger.info("Forcing cache update.")
     else:
         if cache_path.is_file():
-            last_modified_date = datetime.fromtimestamp(os.path.getmtime(cache_path))
+            last_modified_date = datetime.fromtimestamp(os.path.getmtime(str(cache_path)))
             now = datetime.now()
             if (now - last_modified_date).days < cache_days:
                 cache_used = True
                 logging.info("Loading cache...")
-                with open(cache_path,mode="r",encoding="utf-8") as cache_file:
+                with open(str(cache_path),mode="r",encoding="utf-8") as cache_file:
                     cache = json.load(cache_file)
                     episodes = []
                     for e in cache:
@@ -87,7 +88,7 @@ def start():
         logging.info("Fetching online data...")
         episodes = WikipdediaDEGrabber().episodes
         logger.info("Storing cache...")
-        with open(cache_path,mode="w",encoding="utf-8") as cache_file:
+        with open(str(cache_path),mode="w",encoding="utf-8") as cache_file:
             json.dump([episode.as_dict for episode in episodes], cache_file)
     
     # identify files to process

--- a/src/tatorterp/cli.py
+++ b/src/tatorterp/cli.py
@@ -42,7 +42,7 @@ def start():
     # get arguments
     home = os.path.expanduser("~")
     default_cache_path = "{}/.tatorter.cache".format(home)
-    argparser = argparse.ArgumentParser()
+    argparser = argparse.ArgumentParser(fromfile_prefix_chars='@')
     argparser.add_argument(
         "-c","--cache",
         help="file for caching episode data (default: {})".format(default_cache_path),

--- a/src/tatorterp/grabber.py
+++ b/src/tatorterp/grabber.py
@@ -84,11 +84,11 @@ class WikipdediaDEGrabber(object):
         self.episodes = []
         last_epsiode = None
         last_values = None
+        season = None
         for tr in trs[1:]:
             tds = tr.find_all('td')
             values = [td.text.split('(')[0].strip() for td in tds]
             episode_index = int(values[0].replace('a*','').replace('b*',''))
-            # some special treatments
             if episode_index == 835:
                 assert len(values) == 7
                 values[6] = last_epsiode.author
@@ -106,16 +106,24 @@ class WikipdediaDEGrabber(object):
                 location = "[{}]".format(team)
             else:
                 location = team_to_location[team]
+            # strip of trailing [footnote]
+            premiere = values[3].split('[')[0]
+            year = int(premiere[-4:])
+            if season != year:
+                season = year
+                first_episode = episode_index
             episode = Episode(
                 episode_index = episode_index,
                 location = location,
                 title = values[1],
                 broadcaster = values[2],
-                premiere = values[3],
+                premiere = premiere,
                 team = team,
                 case_index = values[5],
                 author = values[6],
-                director = values[7]
+                director = values[7],
+                episode = episode_index - first_episode + 1,
+                season = season
             )
             self.episodes.append(episode)
             last_epsiode = episode


### PR DESCRIPTION
I discovered tatorter when I started to think about using fuzzywuzzy to match my downloaded Tatort episodes.

I needed support for a season (year of premiere) and episode (running episode within the year) naming scheme, so that Plex can lookup the episode summary in TVDB. I added support for that and since I wanted to use it I also added support for changing the naming pattern including reading the naming pattern from disk.

Let me know if you would prefer these as separate pull requests. The changes grew somewhat organically.
